### PR TITLE
throwing a WindowsError with the code

### DIFF
--- a/send2trash/plat_win.py
+++ b/send2trash/plat_win.py
@@ -54,6 +54,4 @@ def send2trash(path):
     fileop.lpszProgressTitle = None
     result = SHFileOperationW(byref(fileop))
     if result:
-        msg = "Couldn't perform operation. Error code: %d" % result
-        raise OSError(msg)
-
+        raise WindowsError(None, None, path, result)


### PR DESCRIPTION
Sometimes one wants to check the specific error code. This should work on py2.7 and py3. WindowsError is derived from OSError, so it should be compatible with previous versions. The message is generated automatically this way.