### PR TITLE
Include LICENSE in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include CHANGES.rst
+include CHANGES.rst LICENSE


### PR DESCRIPTION
Hi! Thanks for the really useful tool!

It would be lovely if the distributed package contained the full license text.

Background: We're looking to package `send2trash` for `conda` over on [conda-forge](https://github.com/conda-forge/staged-recipes/pull/4746), and generally try to include licenses explicitly. At present, the proposed PR just has a copy your your license, but it's preferable if `setuptools` does the heavy lifting.

Happy to add you there as a maintainer, as well, if you are interested!