### PR TITLE
Define TrashPermissionError

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,15 @@ Usage
 >>> from send2trash import send2trash
 >>> send2trash('some_file')
 
-When there's a problem ``OSError`` is raised.
+On Freedesktop platforms (Linux, BSD, etc.), you may not be able to efficiently
+trash some files. In these cases, an exception ``send2trash.TrashPermissionError``
+is raised, so that the application can handle this case. This inherits from
+``PermissionError`` (``OSError`` on Python 2). Specifically, this affects
+files on a different device to the user's home directory, where the root of the
+device does not have a ``.Trash`` directory, and we don't have permission to
+create a ``.Trash-$UID`` directory.
+
+For any other problem, ``OSError`` is raised.
 
 .. _PyGObject: https://wiki.gnome.org/PyGObject
 .. _GIO: https://developer.gnome.org/gio/

--- a/send2trash/__init__.py
+++ b/send2trash/__init__.py
@@ -6,6 +6,8 @@
 
 import sys
 
+from .exceptions import TrashPermissionError
+
 if sys.platform == 'darwin':
     from .plat_osx import send2trash
 elif sys.platform == 'win32':

--- a/send2trash/exceptions.py
+++ b/send2trash/exceptions.py
@@ -1,0 +1,25 @@
+import errno
+from .compat import PY3
+
+if PY3:
+    _permission_error = PermissionError
+else:
+    _permission_error = OSError
+
+class TrashPermissionError(_permission_error):
+    """A permission error specific to a trash directory.
+
+    Raising this error indicates that permissions prevent us efficiently
+    trashing a file, although we might still have permission to delete it.
+    This is *not* used when permissions prevent removing the file itself:
+    that will be raised as a regular PermissionError (OSError on Python 2).
+
+    Application code that catches this may try to simply delete the file,
+    or prompt the user to decide, or (on Freedesktop platforms), move it to
+    'home trash' as a fallback. This last option probably involves copying the
+    data between partitions, devices, or network drives, so we don't do it as
+    a fallback.
+    """
+    def __init__(self, filename):
+        _permission_error.__init__(self, errno.EACCES, "Permission denied",
+                                   filename)


### PR DESCRIPTION
My attempt to tackle #20.

This is still somewhat suboptimal, because it only works if the pure-Python XDG trash implementation is used; if gobject bindings are available, the `plat_gio` module is used instead, so the error never gets used.

I've played around with the gio implementation. It looks like the case I care about gives G_IO_ERROR_NOT_SUPPORTED. That's different from the permission denied error when trying to trash a file we don't have the right access to, but I don't know if there are other conditions which will result in 'not supported' errors.