### PR TITLE
Raise TrashPermissionError from gio backend

### DIFF
--- a/send2trash/plat_gio.py
+++ b/send2trash/plat_gio.py
@@ -5,10 +5,15 @@
 # http://www.hardcoded.net/licenses/bsd_license
 
 from gi.repository import GObject, Gio
+from .exceptions import TrashPermissionError
 
 def send2trash(path):
     try:
         f = Gio.File.new_for_path(path)
         f.trash(cancellable=None)
     except GObject.GError as e:
+        if e.code == Gio.IOErrorEnum.NOT_SUPPORTED:
+            # We get here if we can't create a trash directory on the same
+            # device. I don't know if other errors can result in NOT_SUPPORTED.
+            raise TrashPermissionError('')
         raise OSError(e.message)


### PR DESCRIPTION
I'd like to try turning NOT_SUPPORTED errors from Gio into `TrashPermissionError` to match the pure-Python XDG backend. I still don't know if other exceptions could end up being erroneously translated, but  I think it's worth a try: Jupyter code can't rely on TrashPermissionError for this purpose unless both XDG backends raise it.