### PR TITLE
Add Python 3.7 and Windows to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,24 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+matrix:
+  include:
+    # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
+    - python: "3.7"
+      dist: xenial
+    - os: windows
+      language: sh
+      python: 3
+      # Perform the manual steps on windows to install python3 and tox
+      before_install:
+        - choco install python3 --params "/InstallDir:C:\Python"
+        - export PATH="/c/Python:/c/Python/Scripts:$PATH"
+        - python -m pip install --upgrade pip
+      before_script:
+        - export TOXENV=py3-win
 install:
-  - "pip install tox"
+  - pip install tox
+before_script:
+  - export TOXENV=$(echo py$TRAVIS_PYTHON_VERSION | tr -d .)
 script:
-  - "tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)"
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,24 @@
 language: python
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
 matrix:
   include:
-    # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
-    - python: "3.7"
-      dist: xenial
     - os: windows
       language: sh
       python: 3
-      # Perform the manual steps on windows to install python3 and tox
+      # Perform the manual steps on windows to install python3
       before_install:
         - choco install python3 --params "/InstallDir:C:\Python"
         - export PATH="/c/Python:/c/Python/Scripts:$PATH"
         - python -m pip install --upgrade pip
       before_script:
         - export TOXENV=py3-win
+
+    - python: "2.7"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
+    # Obtain Python 3.7 from xenial as per https://github.com/travis-ci/travis-ci/issues/9815
+    - python: "3.7"
+      dist: xenial
 install:
   - pip install tox
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,16 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py3-win
 skip_missing_interpreters = True
 
 [testenv]
+platform = linux
 commands =
     python setup.py test
+
+[testenv:py3-win]
+platform = win
+commands =
+    python setup.py test --test-suite tests.test_plat_win
 
 [testenv:py27]
 deps =


### PR DESCRIPTION
Python is still not officially supported on Travis-CI Windows builds, so I used a workaround.